### PR TITLE
Add Gateio REST API crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "exc-symbol",
     "exc-okx",
     "exc-binance",
+    "exc-gateio",
     "examples",
 ]
 resolver = "2"
@@ -31,6 +32,7 @@ exc-make = { version = "0.7.3-nightly", path = "./exc-make", default-features = 
 exc-core = { version = "0.7.3-nightly", path = "./exc-core", default-features = false }
 exc-binance = { version = "0.7.3-nightly", path = "./exc-binance", default-features = false }
 exc-okx = { version = "0.7.3-nightly", path = "./exc-okx", default-features = false }
+exc-gateio = { version = "0.7.3-nightly", path = "./exc-gateio", default-features = false }
 exc = { path = "./exc", default-features = false }
 
 indicator = "0.4.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 exc = { workspace = true, features = [
     "okx",
     "binance",
+    "gateio",
     "instrument",
     "poll",
     "rustls-tls",
@@ -17,6 +18,7 @@ exc = { workspace = true, features = [
 ] }
 exc-okx = { workspace = true }
 exc-binance = { workspace = true }
+exc-gateio = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter", "json"] }

--- a/examples/examples/gateio_fetch_tickers.rs
+++ b/examples/examples/gateio_fetch_tickers.rs
@@ -1,0 +1,26 @@
+use exc::prelude::*;
+use futures::future::TryFutureExt;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(tracing_subscriber::EnvFilter::new(
+            std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
+        ))
+        .init();
+
+    let settle = std::env::var("SETTLE").unwrap_or_else(|_| "usdt".to_string());
+
+    let mut gateio = exc::Gateio::endpoint().connect_exc();
+    let req = exc_gateio::GateioRequest::ListFuturesTickers {
+        settle,
+        contract: None,
+    };
+    match gateio.request(req).await {
+        Ok(resp) => println!("{}", resp.into_inner()),
+        Err(err) => eprintln!("request error: {err}"),
+    }
+
+    Ok(())
+}

--- a/exc-gateio/Cargo.toml
+++ b/exc-gateio/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "exc-gateio"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+readme = "./README.md"
+description = "Gate.io exchange services"
+keywords = ["exchange", "tower", "gateio"]
+
+[features]
+default = ["rustls-tls"]
+native-tls = ["exc-core/native-tls"]
+rustls-tls = ["exc-core/rustls-tls"]
+
+[dependencies]
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+hyper = { workspace = true, features = ["client", "http1"] }
+exc-core = { workspace = true, default-features = false, features = ["http", "retry"] }
+tower = { workspace = true, features = ["util", "buffer", "retry"] }
+tokio = { workspace = true, features = ["sync", "rt-multi-thread", "time", "macros"] }
+time = { workspace = true, features = ["serde-human-readable", "macros"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/exc-gateio/README.md
+++ b/exc-gateio/README.md
@@ -1,0 +1,24 @@
+# exc-gateio
+
+Gate.io exchange REST API support for the `exc` ecosystem.
+
+Currently provides a minimal HTTP client with signed requests and an endpoint
+builder. Example usage:
+
+```rust
+use exc_gateio::{Gateio, GateioRequest};
+
+#[tokio::main]
+async fn main() {
+    let mut api = Gateio::endpoint().connect_exc();
+    let res = api
+        .request(GateioRequest::ListFuturesTickers {
+            settle: "usdt".to_string(),
+            contract: None,
+        })
+        .await
+        .unwrap();
+    println!("{}", res.into_inner());
+}
+```
+

--- a/exc-gateio/src/http/layer.rs
+++ b/exc-gateio/src/http/layer.rs
@@ -1,0 +1,112 @@
+use exc_core::{retry::RetryPolicy, ExchangeError};
+use futures::future::{ready, BoxFuture};
+use futures::{FutureExt, TryFutureExt};
+use http::{Request, Response};
+use hyper::Body;
+use tower::{retry::Retry, Layer, Service, ServiceBuilder};
+
+use super::request::HttpRequest;
+use super::response::HttpResponse;
+use crate::key::GateioKey;
+
+/// Gate.io HTTP API layer.
+#[derive(Clone)]
+pub struct GateioHttpApiLayer {
+    host: String,
+    key: Option<GateioKey>,
+    retry: RetryPolicy<HttpRequest, HttpResponse, fn(&ExchangeError) -> bool>,
+}
+
+impl Default for GateioHttpApiLayer {
+    fn default() -> Self {
+        Self {
+            host: "https://api.gateio.ws/api/v4".to_string(),
+            key: None,
+            retry: RetryPolicy::never(),
+        }
+    }
+}
+
+impl GateioHttpApiLayer {
+    /// Set API key.
+    pub fn key(mut self, key: GateioKey) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    /// Set host.
+    pub fn host(mut self, host: &str) -> Self {
+        self.host = host.to_string();
+        self
+    }
+
+    /// Retry on function.
+    pub fn retry_on(self, f: fn(&ExchangeError) -> bool) -> Self {
+        Self { retry: RetryPolicy::default().retry_on(f), ..self }
+    }
+}
+
+impl<S> Layer<S> for GateioHttpApiLayer
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone,
+    S::Future: Send + 'static,
+    S::Error: 'static,
+    ExchangeError: From<S::Error>,
+{
+    type Service = Retry<RetryPolicy<HttpRequest, HttpResponse, fn(&ExchangeError) -> bool>, GateioHttpApi<S>>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        let svc = GateioHttpApi {
+            host: self.host.clone(),
+            http: inner,
+            key: self.key.clone(),
+        };
+        ServiceBuilder::default()
+            .retry(self.retry.clone())
+            .service(svc)
+    }
+}
+
+/// Gate.io HTTP API Service.
+#[derive(Clone)]
+pub struct GateioHttpApi<S> {
+    host: String,
+    key: Option<GateioKey>,
+    http: S,
+}
+
+impl<S> Service<HttpRequest> for GateioHttpApi<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>>,
+    S::Future: Send + 'static,
+    S::Error: 'static,
+    ExchangeError: From<S::Error>,
+{
+    type Response = HttpResponse;
+    type Error = ExchangeError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+        self.http.poll_ready(cx).map_err(ExchangeError::from)
+    }
+
+    fn call(&mut self, req: HttpRequest) -> Self::Future {
+        let host = self.host.clone();
+        let key = self.key.clone();
+        match req.to_request(&host, key.as_ref()) {
+            Ok(req) => {
+                self.http
+                    .call(req)
+                    .map_err(ExchangeError::from)
+                    .and_then(|resp| {
+                        hyper::body::to_bytes(resp.into_body())
+                            .map_err(|e| ExchangeError::Other(e.into()))
+                    })
+                    .and_then(|bytes| ready(serde_json::from_slice::<serde_json::Value>(&bytes).map_err(|e| ExchangeError::Other(e.into()))))
+                    .map_ok(HttpResponse)
+                    .boxed()
+            }
+            Err(err) => ready(Err(err)).boxed(),
+        }
+    }
+}

--- a/exc-gateio/src/http/mod.rs
+++ b/exc-gateio/src/http/mod.rs
@@ -1,0 +1,7 @@
+/// HTTP API layer and types.
+
+pub mod layer;
+pub mod request;
+pub mod response;
+
+pub use layer::GateioHttpApi;

--- a/exc-gateio/src/http/request/mod.rs
+++ b/exc-gateio/src/http/request/mod.rs
@@ -1,0 +1,87 @@
+use http::{Method, Request};
+use serde::Serialize;
+
+use crate::key::GateioKey;
+
+use super::response::HttpResponse;
+use exc_core::ExchangeError;
+
+/// HTTP request variants.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum HttpRequest {
+    /// List futures tickers.
+    ListFuturesTickers {
+        settle: String,
+        #[serde(skip_serializing_if = "Option::is_none")] contract: Option<String>,
+    },
+    /// Get a single futures contract.
+    GetFuturesContract { settle: String, contract: String },
+    /// List all futures contracts.
+    ListFuturesContracts { settle: String },
+    /// List all currencies' details.
+    ListCurrencies,
+    /// Get details of a specific currency.
+    GetCurrency { currency: String },
+}
+
+impl HttpRequest {
+    pub(crate) fn method(&self) -> Method {
+        Method::GET
+    }
+
+    pub(crate) fn path(&self) -> String {
+        match self {
+            Self::ListFuturesTickers { settle, .. } => format!("/futures/{}/tickers", settle),
+            Self::GetFuturesContract { settle, contract } => {
+                format!("/futures/{}/contracts/{}", settle, contract)
+            }
+            Self::ListFuturesContracts { settle } => {
+                format!("/futures/{}/contracts", settle)
+            }
+            Self::ListCurrencies => String::from("/spot/currencies"),
+            Self::GetCurrency { currency } => {
+                format!("/spot/currencies/{}", currency)
+            }
+        }
+    }
+
+    pub(crate) fn query(&self) -> Option<String> {
+        match self {
+            Self::ListFuturesTickers { contract: Some(c), .. } => {
+                Some(format!("contract={}", c))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn to_request(
+        &self,
+        host: &str,
+        key: Option<&GateioKey>,
+    ) -> Result<Request<hyper::Body>, ExchangeError> {
+        let method = self.method();
+        let path = self.path();
+        let query = self.query();
+        let uri = match &query {
+            Some(q) => format!("{}{}?{}", host, &path, q),
+            None => format!("{}{}", host, &path),
+        };
+        let mut builder = Request::builder().method(&method).uri(uri);
+        if let Some(key) = key {
+            let sign = key
+                .sign_now(method.as_str(), &path, query.as_deref(), None)
+                .map_err(|e| ExchangeError::Other(e.into()))?;
+            builder = builder
+                .header("KEY", key.key.as_str())
+                .header("Timestamp", sign.timestamp.as_str())
+                .header("SIGN", sign.sign.as_str());
+        }
+        builder
+            .body(hyper::Body::empty())
+            .map_err(|e| ExchangeError::Other(e.into()))
+    }
+}
+
+/// HTTP response.
+pub type HttpResponseData = HttpResponse;

--- a/exc-gateio/src/http/response.rs
+++ b/exc-gateio/src/http/response.rs
@@ -1,0 +1,18 @@
+use serde::Deserialize;
+
+/// Raw HTTP response data.
+#[derive(Debug, Deserialize)]
+pub struct HttpResponse(serde_json::Value);
+
+impl From<serde_json::Value> for HttpResponse {
+    fn from(v: serde_json::Value) -> Self {
+        Self(v)
+    }
+}
+
+impl HttpResponse {
+    /// Access underlying json value.
+    pub fn into_inner(self) -> serde_json::Value {
+        self.0
+    }
+}

--- a/exc-gateio/src/key.rs
+++ b/exc-gateio/src/key.rs
@@ -1,0 +1,95 @@
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use exc_core::Str;
+
+/// Signing error.
+#[derive(Debug, Error)]
+pub enum SignError {
+    /// Secret key length error.
+    #[error("secret key length error")]
+    SecretKeyLength,
+
+    /// Timestamp formatting error.
+    #[error("timestamp format error: {0}")]
+    Timestamp(#[from] time::error::Format),
+}
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// Gate.io API key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GateioKey {
+    /// API key.
+    pub key: Str,
+    /// Secret.
+    pub secret: Str,
+}
+
+/// Signature result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Signature {
+    /// Signature string.
+    #[serde(rename = "SIGN")]
+    pub sign: Str,
+    /// Timestamp used.
+    #[serde(rename = "Timestamp")]
+    pub timestamp: Str,
+}
+
+impl GateioKey {
+    /// Create new key.
+    pub fn new(key: &str, secret: &str) -> Self {
+        Self {
+            key: Str::new(key),
+            secret: Str::new(secret),
+        }
+    }
+
+    /// Sign with given parameters at specific time.
+    pub fn sign_at(
+        &self,
+        method: &str,
+        path: &str,
+        query: Option<&str>,
+        body: Option<&str>,
+        time: OffsetDateTime,
+    ) -> Result<Signature, SignError> {
+        let ts = time.format(&Rfc3339)?;
+        let mut hasher = Sha512::new();
+        if let Some(body) = body {
+            hasher.update(body.as_bytes());
+        }
+        let hashed = format!("{:x}", hasher.finalize());
+        let raw = format!(
+            "{}\n{}\n{}\n{}\n{}",
+            method,
+            path,
+            query.unwrap_or(""),
+            hashed,
+            ts
+        );
+        let mut mac =
+            HmacSha512::new_from_slice(self.secret.as_str().as_bytes()).map_err(|_| SignError::SecretKeyLength)?;
+        mac.update(raw.as_bytes());
+        let sign = hex::encode(mac.finalize().into_bytes());
+        Ok(Signature {
+            sign: Str::new(sign),
+            timestamp: Str::new(ts),
+        })
+    }
+
+    /// Sign with current timestamp.
+    pub fn sign_now(
+        &self,
+        method: &str,
+        path: &str,
+        query: Option<&str>,
+        body: Option<&str>,
+    ) -> Result<Signature, SignError> {
+        self.sign_at(method, path, query, body, OffsetDateTime::now_utc())
+    }
+}

--- a/exc-gateio/src/lib.rs
+++ b/exc-gateio/src/lib.rs
@@ -1,0 +1,14 @@
+//! Gate.io exchange services.
+
+#![deny(missing_docs)]
+
+/// REST API support.
+pub mod http;
+
+/// API Key utilities.
+pub mod key;
+
+/// Service definitions.
+pub mod service;
+
+pub use crate::service::{Endpoint, Gateio, GateioRequest, GateioResponse};

--- a/exc-gateio/src/service/mod.rs
+++ b/exc-gateio/src/service/mod.rs
@@ -1,0 +1,105 @@
+use exc_core::transport::http::{channel::HttpsChannel, endpoint::Endpoint as HttpEndpoint};
+use exc_core::{Exc, ExchangeError};
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use tower::{buffer::Buffer, Service};
+
+use crate::http::{
+    layer::{GateioHttpApi, GateioHttpApiLayer},
+    request::HttpRequest,
+    response::HttpResponse,
+};
+use crate::key::GateioKey;
+
+/// Gate.io request.
+pub type GateioRequest = HttpRequest;
+
+/// Gate.io response.
+pub type GateioResponse = HttpResponse;
+
+/// Service for Gate.io HTTP API.
+#[derive(Clone)]
+pub struct Gateio {
+    inner: Buffer<GateioHttpApi<HttpsChannel>, GateioRequest>,
+}
+
+impl Service<GateioRequest> for Gateio {
+    type Response = GateioResponse;
+    type Error = ExchangeError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(ExchangeError::from)
+    }
+
+    fn call(&mut self, req: GateioRequest) -> Self::Future {
+        self.inner.call(req).map_err(ExchangeError::from).boxed()
+    }
+}
+
+impl Gateio {
+    fn new(inner: GateioHttpApi<HttpsChannel>, cap: usize) -> Self {
+        Gateio {
+            inner: Buffer::new(inner, cap),
+        }
+    }
+
+    /// Create a default endpoint.
+    pub fn endpoint() -> Endpoint {
+        Endpoint::default()
+    }
+}
+
+/// Endpoint builder.
+pub struct Endpoint {
+    host: String,
+    key: Option<GateioKey>,
+    buffer: usize,
+}
+
+impl Default for Endpoint {
+    fn default() -> Self {
+        Self {
+            host: "https://api.gateio.ws/api/v4".to_string(),
+            key: None,
+            buffer: 128,
+        }
+    }
+}
+
+impl Endpoint {
+    /// Set custom host.
+    pub fn host(mut self, host: &str) -> Self {
+        self.host = host.to_string();
+        self
+    }
+
+    /// Private mode.
+    pub fn private(mut self, key: GateioKey) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    /// Buffer capacity.
+    pub fn buffer(mut self, cap: usize) -> Self {
+        self.buffer = cap;
+        self
+    }
+
+    /// Connect to service.
+    pub fn connect(&self) -> Gateio {
+        let mut layer = GateioHttpApiLayer::default().host(&self.host);
+        if let Some(key) = self.key.clone() {
+            layer = layer.key(key);
+        }
+        let http = HttpEndpoint::default().connect_https();
+        let svc = layer.layer(http);
+        Gateio::new(svc, self.buffer)
+    }
+
+    /// Connect and convert into an exc service.
+    pub fn connect_exc(&self) -> Exc<Gateio, GateioRequest> {
+        Exc::new(self.connect())
+    }
+}
+

--- a/exc/Cargo.toml
+++ b/exc/Cargo.toml
@@ -31,11 +31,13 @@ rustls-tls = [
     "exc-core/rustls-tls",
     "exc-okx?/rustls-tls",
     "exc-binance?/rustls-tls",
+    "exc-gateio?/rustls-tls",
 ]
 
 okx = ["exc-okx"]
 okx-prefer-client-id = ["okx", "exc-okx/prefer-client-id"]
 binance = ["exc-binance"]
+gateio = ["exc-gateio"]
 websocket = ["exc-core/websocket"]
 driven = ["exc-core/driven"]
 http = ["exc-core/http"]
@@ -62,6 +64,7 @@ tokio = { workspace = true, features = ["rt", "sync", "macros", "time"] }
 
 exc-okx = { workspace = true, default-features = false, optional = true }
 exc-binance = { workspace = true, default-features = false, optional = true }
+exc-gateio = { workspace = true, default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/exc/src/lib.rs
+++ b/exc/src/lib.rs
@@ -47,6 +47,9 @@ pub mod prelude {
 
     #[cfg(feature = "binance")]
     pub use crate::Binance;
+
+    #[cfg(feature = "gateio")]
+    pub use crate::Gateio;
 }
 
 /// The result type of `exc`.
@@ -67,8 +70,17 @@ pub mod binance {
     pub use exc_binance::*;
 }
 
+#[cfg(feature = "gateio")]
+/// Gate.io exchange service.
+pub mod gateio {
+    pub use exc_gateio::*;
+}
+
 #[cfg(feature = "okx")]
 pub use crate::okx::Okx;
 
 #[cfg(feature = "binance")]
 pub use crate::binance::Binance;
+
+#[cfg(feature = "gateio")]
+pub use crate::gateio::Gateio;


### PR DESCRIPTION
## Summary
- introduce `exc-gateio` crate implementing Gate.io REST API basics
- wire `exc-gateio` into workspace and `exc` facade
- expose Gateio feature in examples
- enhance gateio module with endpoint builder, connect_exc method, and additional requests
- add Gateio example for fetching tickers

## Testing
- `cargo fmt` *(failed: rustfmt component missing)*
- `cargo check` *(failed: network error when downloading crates)*
